### PR TITLE
Re-disabling one rowsum() test on Windows

### DIFF
--- a/tests/testthat/test_GitHub_issues.R
+++ b/tests/testthat/test_GitHub_issues.R
@@ -29,6 +29,9 @@ test_that("Issue 54 is fixed", {
     rowsum(m4, S))
 
   # RleMatrix
+  # NOTE: This test fails on 32-bit Windows because it can't allocate a ~150 Mb
+  #       vector.
+  skip_on_os("windows")
   m3 <- as(m2, "RleMatrix")
   S <- sample(1:1000, nrow(m3), replace = TRUE)
   expect_equal(


### PR DESCRIPTION
In commit c7ee174 I enabled a rowsum() test that was previously disabled
on Windows (because it can't allocate a ~150 Mb vector when run in 32-bit
mode). I just wanted to give it a try. However, on today's Bioconductor
build report, the test is failing on Windows so I'm disabling it again on
this platform.