### PR TITLE
Pass MatGen namespaced generic rather than just its name.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,12 @@
 Package: DelayedMatrixStats
 Type: Package
 Title: Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects
-Version: 1.11.4
+Version: 1.11.5
+Date: 2020-10-18
 Authors@R: c(person("Peter", "Hickey", role = c("aut", "cre"),
     email = "peter.hickey@gmail.com"),
     person("Hervé", "Pagès", role = "ctb", email = "hpages.on.github@gmail.com"),
     person("Aaron", "Lun", role = "ctb", email = "infinite.monkeys.with.keyboards@gmail.com"))
-Author: Peter Hickey <peter.hickey@gmail.com>
-Maintainer: Peter Hickey <peter.hickey@gmail.com>
 Description: A port of the 'matrixStats' API for use with DelayedMatrix objects 
   from the 'DelayedArray' package. High-performing functions operating on rows 
   and columns of DelayedMatrix objects, e.g. col / rowMedians(), 

--- a/R/colAlls.R
+++ b/R/colAlls.R
@@ -52,7 +52,7 @@
 setMethod("colAlls", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colAlls", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colAlls, 
                                    blockfun = .DelayedMatrix_block_colAlls,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colAnyNAs.R
+++ b/R/colAnyNAs.R
@@ -32,7 +32,7 @@
 setMethod("colAnyNAs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, force_block_processing = FALSE,
                    ...) {
-            .smart_seed_dispatcher(x, generic = "colAnyNAs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colAnyNAs, 
                                    blockfun = .DelayedMatrix_block_colAnyNAs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colAnys.R
+++ b/R/colAnys.R
@@ -48,7 +48,7 @@
 setMethod("colAnys", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colAnys", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colAnys, 
                                    blockfun = .DelayedMatrix_block_colAnys,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colAvgsPerRowSet.R
+++ b/R/colAvgsPerRowSet.R
@@ -65,7 +65,7 @@
 setMethod("colAvgsPerRowSet", "DelayedMatrix",
           function(X, W = NULL, cols = NULL, S, FUN = colMeans, ...,
                    force_block_processing = FALSE, tFUN = FALSE) {
-            .smart_seed_dispatcher(X, generic = "colAvgsPerRowSet", 
+            .smart_seed_dispatcher(X, generic = MatrixGenerics::colAvgsPerRowSet, 
                                    blockfun = .DelayedMatrix_block_colAvgsPerRowSet,
                                    force_block_processing = force_block_processing,
                                    W = W,

--- a/R/colCollapse.R
+++ b/R/colCollapse.R
@@ -69,7 +69,7 @@
 setMethod("colCollapse", "DelayedMatrix",
           function(x, idxs, cols = NULL, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCollapse", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCollapse, 
                                    blockfun = .DelayedMatrix_block_colCollapse,
                                    force_block_processing = force_block_processing,
                                    idxs = idxs,

--- a/R/colCounts.R
+++ b/R/colCounts.R
@@ -54,7 +54,7 @@
 setMethod("colCounts", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCounts", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCounts, 
                                    blockfun = .DelayedMatrix_block_colCounts,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colCummaxs.R
+++ b/R/colCummaxs.R
@@ -49,7 +49,7 @@
 setMethod("colCummaxs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCummaxs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCummaxs, 
                                    blockfun = .DelayedMatrix_block_colCummaxs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colCummins.R
+++ b/R/colCummins.R
@@ -45,7 +45,7 @@
 setMethod("colCummins", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCummins", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCummins, 
                                    blockfun = .DelayedMatrix_block_colCummins,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colCumprods.R
+++ b/R/colCumprods.R
@@ -45,7 +45,7 @@
 setMethod("colCumprods", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCumprods", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCumprods, 
                                    blockfun = .DelayedMatrix_block_colCumprods,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colCumsums.R
+++ b/R/colCumsums.R
@@ -45,7 +45,7 @@
 setMethod("colCumsums", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colCumsums", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colCumsums, 
                                    blockfun = .DelayedMatrix_block_colCumsums,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colDiffs.R
+++ b/R/colDiffs.R
@@ -53,7 +53,7 @@
 setMethod("colDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, lag = 1L, differences = 1L,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colDiffs, 
                                    blockfun = .DelayedMatrix_block_colDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colIQRDiffs.R
+++ b/R/colIQRDiffs.R
@@ -53,7 +53,7 @@
 setMethod("colIQRDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colIQRDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colIQRDiffs, 
                                    blockfun = .DelayedMatrix_block_colIQRDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colIQRs.R
+++ b/R/colIQRs.R
@@ -50,7 +50,7 @@
 setMethod("colIQRs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colIQRs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colIQRs, 
                                    blockfun = .DelayedMatrix_block_colIQRs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colLogSumExps.R
+++ b/R/colLogSumExps.R
@@ -49,7 +49,7 @@
 setMethod("colLogSumExps", "DelayedMatrix",
           function(lx, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(lx, generic = "colLogSumExps", 
+            .smart_seed_dispatcher(lx, generic = MatrixGenerics::colLogSumExps, 
                                    blockfun = .DelayedMatrix_block_colLogSumExps,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colMadDiffs.R
+++ b/R/colMadDiffs.R
@@ -49,7 +49,7 @@
 setMethod("colMadDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colMadDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colMadDiffs, 
                                    blockfun = .DelayedMatrix_block_colMadDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colMads.R
+++ b/R/colMads.R
@@ -67,7 +67,7 @@ setMethod("colMads", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, center = NULL,
                    constant = 1.4826, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colMads", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colMads, 
                                    blockfun = .DelayedMatrix_block_colMads,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colMeans2.R
+++ b/R/colMeans2.R
@@ -50,7 +50,7 @@
 setMethod("colMeans2", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colMeans2", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colMeans2, 
                                    blockfun = .DelayedMatrix_block_colMeans2,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colMedians.R
+++ b/R/colMedians.R
@@ -49,7 +49,7 @@
 setMethod("colMedians", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colMedians", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colMedians, 
                                    blockfun = .DelayedMatrix_block_colMedians,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colOrderStats.R
+++ b/R/colOrderStats.R
@@ -49,7 +49,7 @@
 setMethod("colOrderStats", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, which, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colOrderStats",
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colOrderStats,
                                    blockfun = .DelayedMatrix_block_colOrderStats,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colProds.R
+++ b/R/colProds.R
@@ -51,7 +51,7 @@ setMethod("colProds", "DelayedMatrix",
                    method = c("direct", "expSumLog"),
                    force_block_processing = FALSE, ...) {
             method <- match.arg(method)
-            .smart_seed_dispatcher(x, generic = "colProds", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colProds, 
                                    blockfun = .DelayedMatrix_block_colProds,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colQuantiles.R
+++ b/R/colQuantiles.R
@@ -64,7 +64,7 @@ setMethod("colQuantiles", "DelayedMatrix",
                    probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE,
                    type = 7L, force_block_processing = FALSE, ...,
                    drop = TRUE) {
-            .smart_seed_dispatcher(x, generic = "colQuantiles", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colQuantiles, 
                                    blockfun = .DelayedMatrix_block_colQuantiles,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colRanks.R
+++ b/R/colRanks.R
@@ -56,7 +56,7 @@ setMethod("colRanks", "DelayedMatrix",
                    preserveShape = FALSE,
                    force_block_processing = FALSE, ...) {
             ties.method <- match.arg(ties.method)
-            .smart_seed_dispatcher(x, generic = "colRanks", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colRanks, 
                                    blockfun = .DelayedMatrix_block_colRanks,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colSdDiffs.R
+++ b/R/colSdDiffs.R
@@ -49,7 +49,7 @@
 setMethod("colSdDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colSdDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colSdDiffs, 
                                    blockfun = .DelayedMatrix_block_colSdDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colSums2.R
+++ b/R/colSums2.R
@@ -50,7 +50,7 @@
 setMethod("colSums2", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colSums2", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colSums2, 
                                    blockfun = .DelayedMatrix_block_colSums2,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colTabulates.R
+++ b/R/colTabulates.R
@@ -65,7 +65,7 @@ setMethod("colTabulates", "DelayedMatrix",
               stop("Argument 'x' is not of type integer, logical, or raw",
                    " (type = ", type(x), ")")
             }
-            .smart_seed_dispatcher(x, generic = "colTabulates", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colTabulates, 
                                    blockfun = .DelayedMatrix_block_colTabulates,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colVarDiffs.R
+++ b/R/colVarDiffs.R
@@ -49,7 +49,7 @@
 setMethod("colVarDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colVarDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colVarDiffs, 
                                    blockfun = .DelayedMatrix_block_colVarDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colVars.R
+++ b/R/colVars.R
@@ -65,7 +65,7 @@
 setMethod("colVars", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, center = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colVars", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colVars, 
                                    blockfun = .DelayedMatrix_block_colVars,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/colWeightedMads.R
+++ b/R/colWeightedMads.R
@@ -71,7 +71,7 @@ setMethod("colWeightedMads", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    constant = 1.4826, center = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colWeightedMads", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colWeightedMads, 
                                    blockfun = .DelayedMatrix_block_colWeightedMads,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/colWeightedMeans.R
+++ b/R/colWeightedMeans.R
@@ -56,7 +56,7 @@
 setMethod("colWeightedMeans", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colWeightedMeans", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colWeightedMeans, 
                                    blockfun = .DelayedMatrix_block_colWeightedMeans,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/colWeightedMedians.R
+++ b/R/colWeightedMedians.R
@@ -55,7 +55,7 @@
 setMethod("colWeightedMedians", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colWeightedMedians", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colWeightedMedians, 
                                    blockfun = .DelayedMatrix_block_colWeightedMedians,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/colWeightedVars.R
+++ b/R/colWeightedVars.R
@@ -54,7 +54,7 @@
 setMethod("colWeightedVars", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "colWeightedVars", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::colWeightedVars, 
                                    blockfun = .DelayedMatrix_block_colWeightedVars,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/rowAlls.R
+++ b/R/rowAlls.R
@@ -46,7 +46,7 @@
 setMethod("rowAlls", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowAlls", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowAlls, 
                                    blockfun = .DelayedMatrix_block_rowAlls,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowAnyNAs.R
+++ b/R/rowAnyNAs.R
@@ -21,7 +21,7 @@
 setMethod("rowAnyNAs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, force_block_processing = FALSE,
                    ...) {
-            .smart_seed_dispatcher(x, generic = "rowAnyNAs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowAnyNAs, 
                                    blockfun = .DelayedMatrix_block_rowAnyNAs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowAnys.R
+++ b/R/rowAnys.R
@@ -47,7 +47,7 @@
 setMethod("rowAnys", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowAnys", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowAnys, 
                                    blockfun = .DelayedMatrix_block_rowAnys,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -63,7 +63,7 @@
 setMethod("rowAvgsPerColSet", "DelayedMatrix",
           function(X, W = NULL, rows = NULL, S, FUN = rowMeans, ...,
                    force_block_processing = FALSE, tFUN = FALSE) {
-            .smart_seed_dispatcher(X, generic = "rowAvgsPerColSet", 
+            .smart_seed_dispatcher(X, generic = MatrixGenerics::rowAvgsPerColSet, 
                                    blockfun = .DelayedMatrix_block_rowAvgsPerColSet,
                                    force_block_processing = force_block_processing,
                                    W = W,

--- a/R/rowCollapse.R
+++ b/R/rowCollapse.R
@@ -65,7 +65,7 @@
 setMethod("rowCollapse", "DelayedMatrix",
           function(x, idxs, rows = NULL, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCollapse", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCollapse, 
                                    blockfun = .DelayedMatrix_block_rowCollapse,
                                    force_block_processing = force_block_processing,
                                    idxs = idxs,

--- a/R/rowCounts.R
+++ b/R/rowCounts.R
@@ -49,7 +49,7 @@
 setMethod("rowCounts", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, value = TRUE, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCounts", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCounts, 
                                    blockfun = .DelayedMatrix_block_rowCounts,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowCummaxs.R
+++ b/R/rowCummaxs.R
@@ -45,7 +45,7 @@
 setMethod("rowCummaxs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCummaxs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCummaxs, 
                                    blockfun = .DelayedMatrix_block_rowCummaxs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowCummins.R
+++ b/R/rowCummins.R
@@ -45,7 +45,7 @@
 setMethod("rowCummins", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCummins", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCummins, 
                                    blockfun = .DelayedMatrix_block_rowCummins,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowCumprods.R
+++ b/R/rowCumprods.R
@@ -45,7 +45,7 @@
 setMethod("rowCumprods", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCumprods", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCumprods, 
                                    blockfun = .DelayedMatrix_block_rowCumprods,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowCumsums.R
+++ b/R/rowCumsums.R
@@ -45,7 +45,7 @@
 setMethod("rowCumsums", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowCumsums", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowCumsums, 
                                    blockfun = .DelayedMatrix_block_rowCumsums,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowDiffs.R
+++ b/R/rowDiffs.R
@@ -50,7 +50,7 @@
 setMethod("rowDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, lag = 1L, differences = 1L,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowDiffs, 
                                    blockfun = .DelayedMatrix_block_rowDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowIQRDiffs.R
+++ b/R/rowIQRDiffs.R
@@ -49,7 +49,7 @@
 setMethod("rowIQRDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowIQRDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowIQRDiffs, 
                                    blockfun = .DelayedMatrix_block_rowIQRDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowIQRs.R
+++ b/R/rowIQRs.R
@@ -46,7 +46,7 @@
 setMethod("rowIQRs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowIQRs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowIQRs, 
                                    blockfun = .DelayedMatrix_block_rowIQRs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowLogSumExps.R
+++ b/R/rowLogSumExps.R
@@ -46,7 +46,7 @@
 setMethod("rowLogSumExps", "DelayedMatrix",
           function(lx, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(lx, generic = "rowLogSumExps", 
+            .smart_seed_dispatcher(lx, generic = MatrixGenerics::rowLogSumExps, 
                                    blockfun = .DelayedMatrix_block_rowLogSumExps,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowMadDiffs.R
+++ b/R/rowMadDiffs.R
@@ -49,7 +49,7 @@
 setMethod("rowMadDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowMadDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowMadDiffs, 
                                    blockfun = .DelayedMatrix_block_rowMadDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowMads.R
+++ b/R/rowMads.R
@@ -62,7 +62,7 @@ setMethod("rowMads", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, center = NULL,
                    constant = 1.4826, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowMads", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowMads, 
                                    blockfun = .DelayedMatrix_block_rowMads,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowMeans2.R
+++ b/R/rowMeans2.R
@@ -53,7 +53,7 @@
 setMethod("rowMeans2", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowMeans2", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowMeans2, 
                                    blockfun = .DelayedMatrix_block_rowMeans2,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowMedians.R
+++ b/R/rowMedians.R
@@ -45,7 +45,7 @@
 setMethod("rowMedians", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowMedians", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowMedians, 
                                    blockfun = .DelayedMatrix_block_rowMedians,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowOrderStats.R
+++ b/R/rowOrderStats.R
@@ -47,7 +47,7 @@
 setMethod("rowOrderStats", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, which, 
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowOrderStats", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowOrderStats, 
                                    blockfun = .DelayedMatrix_block_rowOrderStats,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowProds.R
+++ b/R/rowProds.R
@@ -51,7 +51,7 @@ setMethod("rowProds", "DelayedMatrix",
                    method = c("direct", "expSumLog"),
                    force_block_processing = FALSE, ...) {
             method <- match.arg(method)
-            .smart_seed_dispatcher(x, generic = "rowProds", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowProds, 
                                    blockfun = .DelayedMatrix_block_rowProds,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowQuantiles.R
+++ b/R/rowQuantiles.R
@@ -60,7 +60,7 @@ setMethod("rowQuantiles", "DelayedMatrix",
                    probs = seq(from = 0, to = 1, by = 0.25), na.rm = FALSE,
                    type = 7L, force_block_processing = FALSE, ...,
                    drop = TRUE) {
-            .smart_seed_dispatcher(x, generic = "rowQuantiles", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowQuantiles, 
                                    blockfun = .DelayedMatrix_block_rowQuantiles,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowRanks.R
+++ b/R/rowRanks.R
@@ -49,7 +49,7 @@ setMethod("rowRanks", "DelayedMatrix",
                    ties.method = c("max", "average", "first", "last", "random", "max", "min", "dense"),
                    force_block_processing = FALSE, ...) {
             ties.method <- match.arg(ties.method)
-            .smart_seed_dispatcher(x, generic = "rowRanks", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowRanks, 
                                    blockfun = .DelayedMatrix_block_rowRanks,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowSdDiffs.R
+++ b/R/rowSdDiffs.R
@@ -49,7 +49,7 @@
 setMethod("rowSdDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowSdDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowSdDiffs, 
                                    blockfun = .DelayedMatrix_block_rowSdDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowSums2.R
+++ b/R/rowSums2.R
@@ -53,7 +53,7 @@
 setMethod("rowSums2", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowSums2", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowSums2, 
                                    blockfun = .DelayedMatrix_block_rowSums2,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowTabulates.R
+++ b/R/rowTabulates.R
@@ -61,7 +61,7 @@ setMethod("rowTabulates", "DelayedMatrix",
               stop("Argument 'x' is not of type integer, logical, or raw",
                    " (type = ", type(x), ")")
             }
-            .smart_seed_dispatcher(x, generic = "rowTabulates", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowTabulates, 
                                    blockfun = .DelayedMatrix_block_rowTabulates,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowVarDiffs.R
+++ b/R/rowVarDiffs.R
@@ -49,7 +49,7 @@
 setMethod("rowVarDiffs", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, diff = 1L,
                    trim = 0, force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowVarDiffs", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowVarDiffs, 
                                    blockfun = .DelayedMatrix_block_rowVarDiffs,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowVars.R
+++ b/R/rowVars.R
@@ -60,7 +60,7 @@
 setMethod("rowVars", "DelayedMatrix",
           function(x, rows = NULL, cols = NULL, na.rm = FALSE, center = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowVars", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowVars, 
                                    blockfun = .DelayedMatrix_block_rowVars,
                                    force_block_processing = force_block_processing,
                                    rows = rows,

--- a/R/rowWeightedMads.R
+++ b/R/rowWeightedMads.R
@@ -67,7 +67,7 @@ setMethod("rowWeightedMads", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    constant = 1.4826, center = NULL,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowWeightedMads", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowWeightedMads, 
                                    blockfun = .DelayedMatrix_block_rowWeightedMads,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/rowWeightedMedians.R
+++ b/R/rowWeightedMedians.R
@@ -47,7 +47,7 @@
 setMethod("rowWeightedMedians", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowWeightedMedians", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowWeightedMedians, 
                                    blockfun = .DelayedMatrix_block_rowWeightedMedians,
                                    force_block_processing = force_block_processing,
                                    w = w,

--- a/R/rowWeightedVars.R
+++ b/R/rowWeightedVars.R
@@ -51,7 +51,7 @@
 setMethod("rowWeightedVars", "DelayedMatrix",
           function(x, w = NULL, rows = NULL, cols = NULL, na.rm = FALSE,
                    force_block_processing = FALSE, ...) {
-            .smart_seed_dispatcher(x, generic = "rowWeightedVars", 
+            .smart_seed_dispatcher(x, generic = MatrixGenerics::rowWeightedVars, 
                                    blockfun = .DelayedMatrix_block_rowWeightedVars,
                                    force_block_processing = force_block_processing,
                                    w = w,


### PR DESCRIPTION
Fixes an immediate problem with `Biobase::rowMedians`, but also insulates against potential issues with other packages. 