### PR TITLE
Fix 2 issues with how the 'center' argument is handled

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DelayedMatrixStats
 Type: Package
 Title: Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects
-Version: 1.13.0
-Date: 2020-10-18
+Version: 1.13.1
+Date: 2020-11-23
 Authors@R: c(person("Peter", "Hickey", role = c("aut", "cre"),
     email = "peter.hickey@gmail.com"),
     person("Hervé", "Pagès", role = "ctb", email = "hpages.on.github@gmail.com"),

--- a/R/colCollapse.R
+++ b/R/colCollapse.R
@@ -37,7 +37,7 @@
     vp <- currentViewport(block.env)
     subset <- makeNindexFromArrayViewport(vp)[[2]]
     if (!is.null(subset)) {
-        idxs <- idxs[subset]
+        idxs <- idxs[as.integer(subset)]
     }
     matrixStats::colCollapse(x, idxs, ...)
 }

--- a/R/colMads.R
+++ b/R/colMads.R
@@ -13,7 +13,18 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == ncol(x))
+      if (!is.null(cols))
+        center <- center[cols]
+    }
+  }
+
+  # Subset 'x'
   x <- ..subset(x, rows, cols)
 
   # Compute result
@@ -32,12 +43,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .colMads_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[2]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     colMads(x, center = center, ...)

--- a/R/colVars.R
+++ b/R/colVars.R
@@ -13,7 +13,18 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == ncol(x))
+      if (!is.null(cols))
+        center <- center[cols]
+    }
+  }
+
+  # Subset 'x'
   x <- ..subset(x, rows, cols)
 
   # Compute result
@@ -31,12 +42,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .colVars_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[2]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     colVars(x, center = center, ...)

--- a/R/colWeightedMads.R
+++ b/R/colWeightedMads.R
@@ -14,11 +14,30 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = FALSE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(rows)) {
-    w <- w[rows]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == nrow(x))
+      if (!is.null(rows))
+        w <- w[rows]
+    }
   }
+
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == ncol(x))
+      if (!is.null(cols))
+        center <- center[cols]
+    }
+  }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- colblock_APPLY(x = x,
@@ -37,12 +56,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .colWeightedMads_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[2]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     colWeightedMads(x, center = center, ...)

--- a/R/colWeightedMeans.R
+++ b/R/colWeightedMeans.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = FALSE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(rows)) {
-    w <- w[rows]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == nrow(x))
+      if (!is.null(rows))
+        w <- w[rows]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- colblock_APPLY(x = x,

--- a/R/colWeightedMedians.R
+++ b/R/colWeightedMedians.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(rows)) {
-    w <- w[rows]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == nrow(x))
+      if (!is.null(rows))
+        w <- w[rows]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- colblock_APPLY(x = x,

--- a/R/colWeightedVars.R
+++ b/R/colWeightedVars.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(rows)) {
-    w <- w[rows]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == nrow(x))
+      if (!is.null(rows))
+        w <- w[rows]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- colblock_APPLY(x = x,

--- a/R/rowCollapse.R
+++ b/R/rowCollapse.R
@@ -38,7 +38,7 @@
     vp <- currentViewport(block.env)
     subset <- makeNindexFromArrayViewport(vp)[[1]]
     if (!is.null(subset)) {
-        idxs <- idxs[subset]
+        idxs <- idxs[as.integer(subset)]
     }
     matrixStats::rowCollapse(x, idxs, ...)
 }

--- a/R/rowMads.R
+++ b/R/rowMads.R
@@ -13,7 +13,18 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == nrow(x))
+      if (!is.null(rows))
+        center <- center[rows]
+    }
+  }
+
+  # Subset 'x'
   x <- ..subset(x, rows, cols)
 
   # Compute result
@@ -32,12 +43,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .rowMads_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[1]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     rowMads(x, center = center, ...)

--- a/R/rowVars.R
+++ b/R/rowVars.R
@@ -13,7 +13,18 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == nrow(x))
+      if (!is.null(rows))
+        center <- center[rows]
+    }
+  }
+
+  # Subset 'x'
   x <- ..subset(x, rows, cols)
 
   # Compute result
@@ -31,12 +42,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .rowVars_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[1]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     rowVars(x, center = center, ...)

--- a/R/rowWeightedMads.R
+++ b/R/rowWeightedMads.R
@@ -14,11 +14,30 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = FALSE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(cols)) {
-    w <- w[cols]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == ncol(x))
+      if (!is.null(cols))
+        w <- w[cols]
+    }
   }
+
+  # Check and subset 'center' (must be either NULL, or a numeric vector of
+  # length 1 or 'nrow(x)')
+  if (!is.null(center)) {
+    stopifnot(is.numeric(center))
+    if (length(center) != 1L) {
+      stopifnot(length(center) == nrow(x))
+      if (!is.null(rows))
+        center <- center[rows]
+    }
+  }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- rowblock_APPLY(x = x,
@@ -37,12 +56,12 @@
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
 .rowWeightedMads_internal <- function(x, center, ...) {
-    if (!is.null(center)) {
+    if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)
         subset <- makeNindexFromArrayViewport(vp)[[1]]
         if (!is.null(subset)) {
-            center <- center[subset]
+            center <- center[as.integer(subset)]
         }
     }
     rowWeightedMads(x, center = center, ...)

--- a/R/rowWeightedMeans.R
+++ b/R/rowWeightedMeans.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = FALSE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(cols)) {
-    w <- w[cols]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == ncol(x))
+      if (!is.null(cols))
+        w <- w[cols]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- rowblock_APPLY(x = x,

--- a/R/rowWeightedMedians.R
+++ b/R/rowWeightedMedians.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(cols)) {
-    w <- w[cols]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == ncol(x))
+      if (!is.null(cols))
+        w <- w[cols]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- rowblock_APPLY(x = x,

--- a/R/rowWeightedVars.R
+++ b/R/rowWeightedVars.R
@@ -13,11 +13,19 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Subset
-  x <- ..subset(x, rows, cols)
-  if (!is.null(w) && !is.null(cols)) {
-    w <- w[cols]
+  # Check and subset 'w' (must be either NULL, or a numeric vector of
+  # length 1 or 'ncol(x)')
+  if (!is.null(w)) {
+    stopifnot(is.numeric(w))
+    if (length(w) != 1L) {
+      stopifnot(length(w) == ncol(x))
+      if (!is.null(cols))
+        w <- w[cols]
+    }
   }
+
+  # Subset 'x'
+  x <- ..subset(x, rows, cols)
 
   # Compute result
   val <- rowblock_APPLY(x = x,


### PR DESCRIPTION
See issue #68 for the details.

This patch fixes **the 1st issue:**
```
library(HDF5Array)
library(DelayedMatrixStats)

m <- matrix(1:30, nrow=6) * 10^(0:5)
M1 <- as(m, "HDF5Matrix")
M2 <- as(t(m), "HDF5Matrix")

# row/colVars():
current <- rowVars(M1, rows=5:6, center=rowMeans(M1))
stopifnot(all.equal(rowVars(M1)[5:6], current))

current <- colVars(M2, cols=5:6, center=colMeans(M2))
stopifnot(all.equal(colVars(M2)[5:6], current))

# row/colMads():
current <- rowMads(M1, rows=5:6, center=rowMedians(M1))
stopifnot(all.equal(rowMads(M1)[5:6], current))

current <- colMads(M2, cols=5:6, center=colMedians(M2))
stopifnot(all.equal(colMads(M2)[5:6], current))

# row/colSds():
current <- rowSds(M1, rows=5:6, center=rowMeans(M1))
stopifnot(all.equal(rowSds(M1)[5:6], current))

current <- colSds(M2, cols=5:6, center=colMeans(M2))
stopifnot(all.equal(colSds(M2)[5:6], current))
```

and **the 2nd issue:**
```
total_data_size <- length(M1) * get_type_size(type(M1))
setAutoBlockSize(total_data_size * 2/3)

# row/colVars():
current <- rowVars(M1, center=rowMeans(M1))
stopifnot(all.equal(rowVars(M1), current))

current <- colVars(M2, center=colMeans(M2))
stopifnot(all.equal(colVars(M2), current))

current <- rowVars(M1, center=0)
rs0 <- rowSums(M1^2) / (ncol(M1) - 1)
stopifnot(all.equal(rs0, current))

current <- colVars(M2, center=0)
cs0 <- colSums(M2^2) / (nrow(M2) - 1)
stopifnot(all.equal(cs0, current))

# row/colMads():
current <- rowMads(M1, center=rowMedians(M1))
stopifnot(all.equal(rowMads(M1), current))

current <- colMads(M2, center=colMedians(M2))
stopifnot(all.equal(colMads(M2), current))

# row/colSds():
current <- rowSds(M1, center=rowMeans(M1))
stopifnot(all.equal(rowSds(M1), current))

current <- colSds(M2, center=colMeans(M2))
stopifnot(all.equal(colSds(M2), current))
```

H.