### PR TITLE
Fix for missing na.rm= argument in *AvgsPer*Set functions.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: DelayedMatrixStats
 Type: Package
 Title: Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects
-Version: 1.13.4
-Date: 2020-01-19
+Version: 1.13.5
+Date: 2020-02-02
 Authors@R: c(person("Peter", "Hickey", role = c("aut", "cre"),
     email = "peter.hickey@gmail.com"),
     person("Hervé", "Pagès", role = "ctb", email = "hpages.on.github@gmail.com"),

--- a/R/colAvgsPerRowSet.R
+++ b/R/colAvgsPerRowSet.R
@@ -8,6 +8,7 @@
 
 .DelayedMatrix_block_colAvgsPerRowSet <- function(X, W = NULL, cols = NULL, S,
                                                   FUN = colMeans, ...,
+                                                  na.rm = NA,
                                                   tFUN = FALSE) {
   # Check input type
   stopifnot(is(X, "DelayedMatrix"))
@@ -35,6 +36,7 @@
                                   W = W,
                                   S = matrix(seq_len(nrow(S))),
                                   FUN = FUN,
+                                  na.rm = na.rm,
                                   tFUN = tFUN)
   })
   if (length(val) == 0L) {
@@ -64,7 +66,7 @@
 #' colAvgsPerRowSet(dm_DF, S = matrix(1:2, ncol = 2))
 setMethod("colAvgsPerRowSet", "DelayedMatrix",
           function(X, W = NULL, cols = NULL, S, FUN = colMeans, ...,
-                   force_block_processing = FALSE, tFUN = FALSE) {
+                   force_block_processing = FALSE, na.rm = NA, tFUN = FALSE) {
             .smart_seed_dispatcher(X, generic = MatrixGenerics::colAvgsPerRowSet, 
                                    blockfun = .DelayedMatrix_block_colAvgsPerRowSet,
                                    force_block_processing = force_block_processing,
@@ -73,6 +75,7 @@ setMethod("colAvgsPerRowSet", "DelayedMatrix",
                                    S = S,
                                    FUN = FUN,
                                    ...,
+                                   na.rm = na.rm,
                                    tFUN = tFUN)
           }
 )

--- a/R/rowAvgsPerColSet.R
+++ b/R/rowAvgsPerColSet.R
@@ -8,6 +8,7 @@
 
 .DelayedMatrix_block_rowAvgsPerColSet <- function(X, W = NULL, rows = NULL, S,
                                                   FUN = rowMeans, ...,
+                                                  na.rm = NA,
                                                   tFUN = FALSE) {
   # Check input type
   stopifnot(is(X, "DelayedMatrix"))
@@ -36,6 +37,7 @@
                                   W = W,
                                   S = matrix(seq_len(nrow(S))),
                                   FUN = FUN,
+                                  na.rm = na.rm,
                                   tFUN = tFUN)
   })
   if (length(val) == 0L) {
@@ -62,7 +64,7 @@
 #' rowAvgsPerColSet(dm_DF, S = matrix(1:2, ncol = 1))
 setMethod("rowAvgsPerColSet", "DelayedMatrix",
           function(X, W = NULL, rows = NULL, S, FUN = rowMeans, ...,
-                   force_block_processing = FALSE, tFUN = FALSE) {
+                   force_block_processing = FALSE, na.rm = NA, tFUN = FALSE) {
             .smart_seed_dispatcher(X, generic = MatrixGenerics::rowAvgsPerColSet, 
                                    blockfun = .DelayedMatrix_block_rowAvgsPerColSet,
                                    force_block_processing = force_block_processing,
@@ -71,6 +73,7 @@ setMethod("rowAvgsPerColSet", "DelayedMatrix",
                                    S = S,
                                    FUN = FUN,
                                    ...,
+                                   na.rm = na.rm,
                                    tFUN = tFUN)
           }
 )

--- a/man/colAvgsPerRowSet.Rd
+++ b/man/colAvgsPerRowSet.Rd
@@ -14,6 +14,7 @@ subsets of columns (rows)}
   FUN = colMeans,
   ...,
   force_block_processing = FALSE,
+  na.rm = NA,
   tFUN = FALSE
 )
 
@@ -25,6 +26,7 @@ subsets of columns (rows)}
   FUN = rowMeans,
   ...,
   force_block_processing = FALSE,
+  na.rm = NA,
   tFUN = FALSE
 )
 }
@@ -52,6 +54,10 @@ to use the general block-processing strategy by setting this to \code{TRUE}
 (typically not advised). The block-processing strategy loads one or more
 (depending on \verb{\link[DelayedArray]\{getAutoBlockSize\}()}) columns (\code{colFoo()})
 or rows (\code{rowFoo()}) into memory as an ordinary \link[base:array]{base::array}.}
+
+\item{na.rm}{(logical) Argument passed to \code{FUN()} as \code{na.rm = na.rm}.
+If \code{NA} (default), then \code{na.rm = TRUE} is used if \code{X} or \code{S} holds missing values,
+otherwise \code{na.rm = FALSE}.}
 
 \item{tFUN}{If \code{TRUE}, \code{X} is transposed before it is passed to \code{FUN}.}
 


### PR DESCRIPTION
Closes #73, #74.