### PR TITLE
Use BLOCK_colVars/BLOCK_rowVars workhorses for colVars/rowVars methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DelayedMatrixStats
 Type: Package
 Title: Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects
-Version: 1.23.0
+Version: 1.23.1
 Date: 2022-10-12
 Authors@R: c(person("Peter", "Hickey", role = c("aut", "cre"),
     email = "peter.hickey@gmail.com"),
@@ -20,7 +20,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Depends:
   MatrixGenerics (>= 1.5.3),
-  DelayedArray (>= 0.17.6)
+  DelayedArray (>= 0.27.8)
 Imports:
   methods,
   matrixStats (>= 0.60.0),

--- a/R/colVars.R
+++ b/R/colVars.R
@@ -28,31 +28,8 @@
   x <- ..subset(x, rows, cols)
 
   # Compute result
-  val <- colblock_APPLY(x = x,
-                        FUN = .colVars_internal,
-                        na.rm = na.rm,
-                        center = center,
-                        ...,
-                        useNames = useNames)
-  if (length(val) == 0L) {
-    return(numeric(ncol(x)))
-  }
-  # NOTE: Return value of matrixStats::colVars() has no names
-  # TODO: Obey top-level `useNames` argument.
-  unlist(val, recursive = FALSE, use.names = FALSE)
-}
-
-#' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
-.colVars_internal <- function(x, center, ..., useNames = NA) {
-    if (!is.null(center) && length(center) != 1L) {
-        block.env <- parent.frame(2)
-        vp <- currentViewport(block.env)
-        subset <- makeNindexFromArrayViewport(vp)[[2]]
-        if (!is.null(subset)) {
-            center <- center[as.integer(subset)]
-        }
-    }
-    colVars(x, center = center, ..., useNames = useNames)
+  DelayedArray:::BLOCK_colVars(x, na.rm = na.rm, center = center,
+                               useNames = isTRUE(useNames))
 }
 
 ### ----------------------------------------------------------------------------

--- a/R/rowVars.R
+++ b/R/rowVars.R
@@ -28,31 +28,8 @@
   x <- ..subset(x, rows, cols)
 
   # Compute result
-  val <- rowblock_APPLY(x = x,
-                        FUN = .rowVars_internal,
-                        na.rm = na.rm,
-                        center = center,
-                        ...,
-                        useNames = useNames)
-  if (length(val) == 0L) {
-    return(numeric(nrow(x)))
-  }
-  # NOTE: Return value of matrixStats::rowVars() has no names
-  # TODO: Obey top-level `useNames` argument.
-  unlist(val, recursive = FALSE, use.names = FALSE)
-}
-
-#' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
-.rowVars_internal <- function(x, center, ..., useNames = NA) {
-    if (!is.null(center) && length(center) != 1L) {
-        block.env <- parent.frame(2)
-        vp <- currentViewport(block.env)
-        subset <- makeNindexFromArrayViewport(vp)[[1]]
-        if (!is.null(subset)) {
-            center <- center[as.integer(subset)]
-        }
-    }
-    rowVars(x, center = center, ..., useNames = useNames)
+  DelayedArray:::BLOCK_rowVars(x, na.rm = na.rm, center = center,
+                               useNames = isTRUE(useNames))
 }
 
 ### ----------------------------------------------------------------------------


### PR DESCRIPTION
Until now, that is, prior to **DelayedMatrixStats** 1.23.1, the `colVars()` and `rowVars()` methods for DelayedMatrix objects were using `colblock_APPLY()` and `rowblock_APPLY()` internally to handle block processing. These utilities use blocks made of _full_ columns and _full_ rows, respectively, regarless of the physical layout of the data on disk. However, this doesn't "play well" with some physical layouts. For example, loading _full_ rows in memory is extremely inefficient in the case of a TENxMatrix object (from the **HDF5Array** package), because it triggers the loading of the _entire_ dataset!

The new `BLOCK_colVars()` and `BLOCK_rowVars()` internal helpers implemented in the **DelayedArray** package address this by trying to choose a block geometry that "plays well" with the physical layout. By delegating the work to these functions, the `colVars()` and `rowVars()` methods for DelayedMatrix objects can be 3x to 10x faster (or more) for datasets with a "difficult" physical layout, while at the same time consume a lot less memory.

Note that the other matrixStats methods defined in **DelayedMatrixStats** also use `colblock_APPLY()` and `rowblock_APPLY()` internally, so will need to be modified in a similar way.