### PR TITLE
Restore scalar center argument for matrix functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DelayedMatrixStats
 Type: Package
 Title: Functions that Apply to Rows and Columns of 'DelayedMatrix' Objects
-Version: 1.25.2
+Version: 1.25.3
 Date: 2024-04-11
 Authors@R: c(person("Peter", "Hickey", role = c("aut", "cre"),
     email = "peter.hickey@gmail.com", comment = c(ORCID = "0000-0002-8153-6258")),
@@ -18,7 +18,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Depends:
-  MatrixGenerics (>= 1.13.1),
+  MatrixGenerics (>= 1.15.1),
   DelayedArray (>= 0.27.10)
 Imports:
   methods,

--- a/R/colMads.R
+++ b/R/colMads.R
@@ -13,15 +13,8 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'ncol(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == ncol(x))
-    if (!is.null(cols)) {
-      center <- center[cols]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, ncol(x), "ncol(x)", cols)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)
@@ -41,7 +34,7 @@
 }
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
-.colMads_internal <- function(x, center, ..., useNames = useNames) {
+.colMads_internal <- function(x, center, ..., useNames = TRUE) {
     if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)

--- a/R/colVars.R
+++ b/R/colVars.R
@@ -13,15 +13,8 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'ncol(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == ncol(x))
-    if (!is.null(cols)) {
-      center <- center[cols]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, ncol(x), "ncol(x)", cols)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)

--- a/R/colWeightedMads.R
+++ b/R/colWeightedMads.R
@@ -25,15 +25,8 @@
     }
   }
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'ncol(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == ncol(x))
-    if (!is.null(cols)) {
-      center <- center[cols]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, ncol(x), "ncol(x)", cols)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)
@@ -54,7 +47,7 @@
 }
 
 #' @importFrom DelayedArray currentViewport makeNindexFromArrayViewport
-.colWeightedMads_internal <- function(x, center, ..., useNames = NA) {
+.colWeightedMads_internal <- function(x, center, ..., useNames = TRUE) {
     if (!is.null(center) && length(center) != 1L) {
         block.env <- parent.frame(2)
         vp <- currentViewport(block.env)

--- a/R/rowMads.R
+++ b/R/rowMads.R
@@ -13,15 +13,8 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'nrow(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == nrow(x))
-    if (!is.null(rows)) {
-        center <- center[rows]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, nrow(x), "nrow(x)", rows)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)

--- a/R/rowVars.R
+++ b/R/rowVars.R
@@ -13,15 +13,8 @@
   stopifnot(is(x, "DelayedMatrix"))
   DelayedArray:::.get_ans_type(x, must.be.numeric = TRUE)
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'nrow(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == nrow(x))
-    if (!is.null(rows)) {
-      center <- center[rows]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, nrow(x), "nrow(x)", rows)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)

--- a/R/rowWeightedMads.R
+++ b/R/rowWeightedMads.R
@@ -25,15 +25,8 @@
     }
   }
 
-  # Check and subset 'center' (must be either NULL, or a numeric vector of
-  # length 'nrow(x)')
-  if (!is.null(center)) {
-    stopifnot(is.numeric(center))
-    stopifnot(length(center) == nrow(x))
-    if (!is.null(rows)) {
-      center <- center[rows]
-    }
-  }
+  # Check, normalize, and subset 'center'
+  center <- normarg_center_and_subset(center, nrow(x), "nrow(x)", rows)
 
   # Subset 'x'
   x <- ..subset(x, rows, cols)

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,15 @@ message2 <- function(msg, verbose = FALSE) {
   }
 }
 
+# Check, normalize, and subset 'center' argument.
+# Supplied 'center' must be either NULL or a numeric vector of length 'n'
+# or 1.
+normarg_center_and_subset <- function(center, n, what, idx=NULL)
+{
+    center <- MatrixGenerics::normarg_center(center, n, what)
+    if (is.null(idx)) center else center[idx]  # 'idx' is trusted
+}
+
 # TODO: Figure out a minimal definition of a "simple seed"; Hervé defines a
 #       "seed contract" as dim(), dimnames(), and extract_array(); see
 #       DelayedArray vignette


### PR DESCRIPTION
As discussed here: https://github.com/Bioconductor/DelayedArray/issues/115

Note that this patch uses `MatrixGenerics::normarg_center()` from **MatrixGenerics** >= 1.15.1 so will only pass CHECK once [this other PR](https://github.com/Bioconductor/MatrixGenerics/pull/38) gets merged and propagates to the BioC 3.19 package repos.

Thanks